### PR TITLE
Update top-pypi-packages filename

### DIFF
--- a/check_packages.py
+++ b/check_packages.py
@@ -10,7 +10,7 @@ import requests
 # this package
 from seed_intersphinx_mapping import get_sphinx_doc_url
 
-url = "https://hugovk.github.io/top-pypi-packages/top-pypi-packages-30-days.json"
+url = "https://hugovk.github.io/top-pypi-packages/top-pypi-packages.json"
 top_packages = [p["project"] for p in requests.get(url).json()["rows"]]
 
 print(top_packages)


### PR DESCRIPTION
To stay within quota, it now has just under 30 days of data, so the filename has been updated. Both will be available for a while. See https://github.com/hugovk/top-pypi-packages/pull/46.